### PR TITLE
Adding negative sign to return Stanford back to CA where it belongs

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ humandate: Jan 27-28, 2014
 humantime: 9:00 am - 4:30 pm
 startdate: 2014-01-27
 enddate: 2014-01-28
-latlng: 37.4225, 122.1653
+latlng: 37.4225,-122.1653
 registration: restricted
 instructor: ["Ariel Rokem", "Justin Kitzes"]
 contact: random@software-carpentry.org


### PR DESCRIPTION
Map pin is currently in Korea.
